### PR TITLE
fix: suppress TypeScript 6.0 moduleResolution=node10 deprecation error

### DIFF
--- a/packages/fluentui-compat/tsconfig.json
+++ b/packages/fluentui-compat/tsconfig.json
@@ -8,6 +8,7 @@
     "lib": ["es2020", "dom", "dom.iterable"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
TypeScript 6.0 deprecated `moduleResolution: node` (node10) and will
remove it in TypeScript 7.0. Add `ignoreDeprecations: "6.0"` to
acknowledge the deprecation and unblock CI until the module resolution
strategy can be properly migrated.

https://claude.ai/code/session_01ApBqavP63MoVvn3W27EAoX